### PR TITLE
Fixing Tritond's --help Output

### DIFF
--- a/bin/tritond
+++ b/bin/tritond
@@ -229,8 +229,8 @@ def main():
         default=None,
         help=
             """
-            Output file for incomeing data; otherwise output to stdout.
-            Only used with --skip-kinesis
+            Output file for incoming data; otherwise output to stdout.
+            Only used in conjunction with --skip-kinesis
             """
     )
 

--- a/bin/tritond
+++ b/bin/tritond
@@ -221,16 +221,17 @@ def main():
         dest='skip_kinesis',
         action='store_true',
         default=False,
-        help="will skip sends to Kinesis; for debug purposess")
+        help="Skip publishing to Kinesis; for debug purposes.")
     parser.add_argument(
         '--output_file',
         dest='output_file',
         action='store',
         default=None,
-        help=(
-            'output file for incomeing data; otherwise output to stdout. ',
-            'Only used with --skip-kinesis'
-        )
+        help=
+            """
+            Output file for incomeing data; otherwise output to stdout.
+            Only used with --skip-kinesis
+            """
     )
 
     options = parser.parse_args()

--- a/tests/test_tritond.py
+++ b/tests/test_tritond.py
@@ -1,0 +1,16 @@
+from testify import *
+
+import os
+import subprocess
+
+class Tritond(TestCase):
+
+    def test_help(self):
+        """
+        Tritond should display help without issue.
+        """
+        with open(os.devnull, "wb") as null:
+            cmd = 'python ./bin/tritond --help'
+            p = subprocess.Popen(cmd.split(' '), stdout=null, stderr=null)
+            p.communicate()
+            assert_equal(p.returncode, 0)


### PR DESCRIPTION
Tuple used as the help field for output_file was resulting in an
Exception when users specified --help.