### PR TITLE
Unicode patch for nonblocking stream

### DIFF
--- a/cfg/requirements.txt
+++ b/cfg/requirements.txt
@@ -1,3 +1,4 @@
+future
 testify
 pep8
 pyflakes

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     author_email=get_init_val('author_email'),
     url=get_init_val('url'),
     scripts=glob.glob("bin/triton*"),
-    install_requires=['python-snappy', 'msgpack_python', 'pyzmq'],
+    install_requires=['python-snappy', 'msgpack_python', 'pyzmq', 'future'],
     packages=PACKAGES
 )

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -157,7 +157,7 @@ class NonblockingStreamTest(TestCase):
         s = nonblocking_stream.NonblockingStream(u'tést_üñîçødé_stream_宇宙', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
         test_data = generate_unicode_data()
         s.put(**test_data)
-        meta_data, message_data = generate_transmitted_record(test_data, stream_name=u'tést_üñîçødé_stream_宇宙')
+        meta_data, message_data = generate_transmitted_record(test_data, stream_name=u'tést_üñîçødé_stream_宇宙', partition_key=u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
         mock_sent_meta_data, mock_sent_message_data = (
             nonblocking_stream.threadLocal
             .zmq_socket.send_multipart.calls[0][0][0])

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -140,7 +140,7 @@ class NonblockingStreamTest(TestCase):
         s = nonblocking_stream.NonblockingStream('tést_unicode_stream', 'pkey')
         test_data = generate_unicode_data()
         s.put(**test_data)
-        meta_data, message_data = generate_transmitted_record(test_data)
+        meta_data, message_data = generate_transmitted_record(test_data, stream_name='tést_unicode_stream')
         mock_sent_meta_data, mock_sent_message_data = (
             nonblocking_stream.threadLocal
             .zmq_socket.send_multipart.calls[0][0][0])

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -278,6 +278,24 @@ class NonblockingStreamEndToEnd(TestCase):
             if stream_name in received_data:
                 assert_equal(len(received_data[stream_name]), 10)
 
+    def test_escaped_unicode_end_to_end(self):
+        stream_name = 'téßt_üñîçø∂é_st®éåµ_宇宙'
+        test_stream = nonblocking_stream.NonblockingStream(
+            stream_name, 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        for i in range(10):
+            test_stream.put(**generate_escaped_unicode_data())
+        time.sleep(1)
+        assert_truthy(os.path.exists(self.log_file))
+        if os.path.exists(self.log_file):
+            with open(self.log_file, u'rb') as output_file:
+                received_data = decode_debug_data(output_file)
+            #NOTE: "escaped" unicode comes out the read-side of the stream as
+            #pure unicode, so we need to convert the stream name to unicode for
+            #assert
+            assert_truthy(ascii_to_unicode_str(stream_name) in received_data)
+            if stream_name in received_data:
+                assert_equal(len(received_data[stream_name]), 10)
+
     def test_multiple_streams(self):
         streams = set(['stream_a', 'stream_b'])
         for stream_name in streams:

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -76,8 +76,8 @@ def generate_transmitted_record(data, stream_name='test_stream', partition_key='
     meta_data = struct.pack(
         nonblocking_stream.META_STRUCT_FMT,
         nonblocking_stream.META_STRUCT_VERSION,
-        stream_name,
-        data[partition_key])
+        stream_name.encode('utf-8'),
+        data[partition_key].encode('utf-8'))
     return meta_data, message_data
 
 

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -231,7 +231,7 @@ class NonblockingStreamTest(TestCase):
             .zmq_socket.send_multipart.calls[0][0][0])
         assert_equal(mock_sent_meta_data, meta_data)
         assert_equal(mock_sent_message_data, message_data)
-        sent_data = msgpack.unpackb(mock_sent_message_data)
+        sent_data = msgpack.unpackb(mock_sent_message_data, encoding='utf-8')
         assert_equal(
             sent_data['time'],
             test_data['time'].isoformat(' '))

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -258,10 +258,25 @@ class NonblockingStreamEndToEnd(TestCase):
         assert_truthy(os.path.exists(self.log_file))
         if os.path.exists(self.log_file):
             with open(self.log_file, 'rb') as output_file:
-                received_data = (decode_debug_data(output_file))
+                received_data = decode_debug_data(output_file)
             assert_truthy(stream_name in received_data)
             if stream_name in received_data:
                 assert_equal(len(received_data[stream_name]), 10)
+
+    # def test_unicode_end_to_end(self):
+    #     stream_name = u'téßt_üñîçø∂é_st®éåµ_宇宙'
+    #     test_stream = nonblocking_stream.NonblockingStream(
+    #         stream_name, u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+    #     for i in range(10):
+    #         test_stream.put(**generate_unicode_data())
+    #     time.sleep(1)
+    #     assert_truthy(os.path.exists(self.log_file))
+    #     if os.path.exists(self.log_file):
+    #         with open(self.log_file, u'rb') as output_file:
+    #             received_data = (decode_debug_data(output_file))
+    #         assert_truthy(stream_name in received_data)
+    #         if stream_name in received_data:
+    #             assert_equal(len(received_data[stream_name]), 10)
 
     def test_multiple_streams(self):
         streams = set(['stream_a', 'stream_b'])

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -137,10 +137,10 @@ class NonblockingStreamTest(TestCase):
         assert_equal(mock_sent_message_data, message_data)
 
     def test_send_unicode_data(self):
-        s = nonblocking_stream.NonblockingStream('tést_unicode_stream', 'pkey')
+        s = nonblocking_stream.NonblockingStream(u'tést_unicode_stream', u'pkey')
         test_data = generate_unicode_data()
         s.put(**test_data)
-        meta_data, message_data = generate_transmitted_record(test_data, stream_name='tést_unicode_stream')
+        meta_data, message_data = generate_transmitted_record(test_data, stream_name=u'tést_unicode_stream')
         mock_sent_meta_data, mock_sent_message_data = (
             nonblocking_stream.threadLocal
             .zmq_socket.send_multipart.calls[0][0][0])

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -63,7 +63,8 @@ def generate_escaped_unicode_data(primary_key='my_key'):
         'pkey': primary_key,
         'value': True,
         'ascii_key': 'sømé_ünîcode_vàl',
-        'ünîcødé_key': 'ascii_val'
+        'ünîcødé_key': 'ascii_val',
+        'ünîcødé_πå®tîtîøñ_ke¥_宇宙': 'ünîcødé_πå®tîtîøñ_√al_宇宙'
     }
     return data
 
@@ -165,11 +166,31 @@ class NonblockingStreamTest(TestCase):
         assert_equal(mock_sent_message_data, message_data)
         #TODO: assert equal for data (see test_send_hard_to_encode_data below)
 
+    def test_send_escaped_unicode_event(self):
+        s = nonblocking_stream.NonblockingStream('tést_üñîçødé_stream_宇宙', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        test_data = generate_escaped_unicode_data()
+        s.put(**test_data)
+        meta_data, message_data = generate_transmitted_record(test_data, stream_name='tést_üñîçødé_stream_宇宙', partition_key='ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        mock_sent_meta_data, mock_sent_message_data = (
+            nonblocking_stream.threadLocal
+            .zmq_socket.send_multipart.calls[0][0][0])
+        assert_equal(mock_sent_meta_data, meta_data)
+        assert_equal(mock_sent_message_data, message_data)
+        #TODO: assert equal for data (see test_send_hard_to_encode_data below)
+
     def test_unicode_serialize_context(self):
         s = nonblocking_stream.NonblockingStream(u'tést_üñîçødé_stream', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
         test_data = generate_unicode_data()
         meta_data, message_data = s._serialize_context(test_data)
         assert_meta_data, assert_message_data = generate_transmitted_record(test_data, stream_name=u'tést_üñîçødé_stream', partition_key=u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        assert_equal(assert_meta_data, meta_data)
+        assert_equal(assert_message_data, message_data)
+
+    def test_escaped_unicode_serialize_context(self):
+        s = nonblocking_stream.NonblockingStream('tést_üñîçødé_stream', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        test_data = generate_escaped_unicode_data()
+        meta_data, message_data = s._serialize_context(test_data)
+        assert_meta_data, assert_message_data = generate_transmitted_record(test_data, stream_name='tést_üñîçødé_stream', partition_key='ünîcødé_πå®tîtîøñ_ke¥_宇宙')
         assert_equal(assert_meta_data, meta_data)
         assert_equal(assert_message_data, message_data)
 

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -120,11 +120,11 @@ def _serialize_context(self, data):
 
 
 def decode_debug_data(file_object):
-    unpacker = msgpack.Unpacker(file_object)
+    unpacker = msgpack.Unpacker(file_object, encoding='utf-8')
     data = defaultdict(list)
     current_list = None
     for item in unpacker:
-        if type(item) == str:
+        if type(item) == unicode:
             current_list = data[item]
         else:
             current_list.append(item)
@@ -263,20 +263,20 @@ class NonblockingStreamEndToEnd(TestCase):
             if stream_name in received_data:
                 assert_equal(len(received_data[stream_name]), 10)
 
-    # def test_unicode_end_to_end(self):
-    #     stream_name = u'téßt_üñîçø∂é_st®éåµ_宇宙'
-    #     test_stream = nonblocking_stream.NonblockingStream(
-    #         stream_name, u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
-    #     for i in range(10):
-    #         test_stream.put(**generate_unicode_data())
-    #     time.sleep(1)
-    #     assert_truthy(os.path.exists(self.log_file))
-    #     if os.path.exists(self.log_file):
-    #         with open(self.log_file, u'rb') as output_file:
-    #             received_data = (decode_debug_data(output_file))
-    #         assert_truthy(stream_name in received_data)
-    #         if stream_name in received_data:
-    #             assert_equal(len(received_data[stream_name]), 10)
+    def test_unicode_end_to_end(self):
+        stream_name = u'téßt_üñîçø∂é_st®éåµ_宇宙'
+        test_stream = nonblocking_stream.NonblockingStream(
+            stream_name, u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        for i in range(10):
+            test_stream.put(**generate_unicode_data())
+        time.sleep(1)
+        assert_truthy(os.path.exists(self.log_file))
+        if os.path.exists(self.log_file):
+            with open(self.log_file, u'rb') as output_file:
+                received_data = decode_debug_data(output_file)
+            assert_truthy(stream_name in received_data)
+            if stream_name in received_data:
+                assert_equal(len(received_data[stream_name]), 10)
 
     def test_multiple_streams(self):
         streams = set(['stream_a', 'stream_b'])

--- a/tests/test_nonblocking_stream.py
+++ b/tests/test_nonblocking_stream.py
@@ -68,13 +68,6 @@ def generate_escaped_unicode_data(primary_key='my_key'):
     }
     return data
 
-#TODO: generate non-futurized ASCII strings!
-
-#NOTE: stream name is guaranteed to be a string, therefore we can safely do
-#.encode('utf-8') to convert to ascii so struct can handle it. But
-#data[partition_key] could return either a unicode string or another non-string
-#value. Therefore, we have to safely convert to a unicode string before encoding,
-#just as NonblockingStream._partition_key does.
 def generate_transmitted_record(data, stream_name='test_stream', partition_key='pkey'):
     message_data = msgpack.packb(
         data, default=msgpack_encode_default)

--- a/triton/encoding.py
+++ b/triton/encoding.py
@@ -20,3 +20,19 @@ def msgpack_encode_default(obj):
         return repr(obj)
     except Exception:
         raise TypeError("Unknown type: %r" % (obj,))
+
+def unicode_to_ascii_str(text):
+    #if unicode, escape out multibyte characters
+    if isinstance(text, unicode):
+        return text.encode('utf-8')
+    else:
+        #need to str here because this function could be fed something
+        #that's not unicode but needs to be an ascii string (e.g. an int)
+        return str(text)
+
+def ascii_to_unicode_str(text):
+    #if ascii/escaped unicode, decode to utf-8
+    if isinstance(text, str):
+        return text.decode('utf-8')
+    else:
+        return unicode(text)

--- a/triton/encoding.py
+++ b/triton/encoding.py
@@ -35,4 +35,6 @@ def ascii_to_unicode_str(text):
     if isinstance(text, str):
         return text.decode('utf-8')
     else:
+        #need to unicode here because this function could be fed something
+        #that's not an ascii str but needs to be a unicode string (e.g. an int)
         return unicode(text)

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -11,7 +11,6 @@ Adapted from https://github.com/rhettg/BlueOx/blob/master/blueox/network.py
 
 """
 from __future__ import unicode_literals
-from builtins import str
 import logging
 import threading
 import struct

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -74,7 +74,7 @@ class NonblockingStream(object):
             init(*config.get_zmq_config())
 
     def _partition_key(self, data):
-        return unicode(data[self.partition_key])
+        return str(data[self.partition_key])
 
     def _serialize_context(self, data):
         # Our sending format is made up of two messages. The first has a

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -72,7 +72,7 @@ class NonblockingStream(object):
             init(*config.get_zmq_config())
 
     def _partition_key(self, data):
-        return str(data[self.partition_key])
+        return unicode(data[self.partition_key])
 
     def _serialize_context(self, data):
         # Our sending format is made up of two messages. The first has a

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -21,7 +21,7 @@ import msgpack
 
 from triton import errors
 from triton import config
-from triton.encoding import msgpack_encode_default
+from triton.encoding import msgpack_encode_default, unicode_to_ascii_str, ascii_to_unicode_str
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class NonblockingStream(object):
             init(*config.get_zmq_config())
 
     def _partition_key(self, data):
-        return unicode(data[self.partition_key])
+        return ascii_to_unicode_str(data[self.partition_key])
 
     def _serialize_context(self, data):
         # Our sending format is made up of two messages. The first has a
@@ -85,8 +85,8 @@ class NonblockingStream(object):
             raise ValueError("Partition Key Too Long")
 
         meta_data = struct.pack(META_STRUCT_FMT, META_STRUCT_VERSION,
-                                self.name.encode('utf-8'),
-                                self._partition_key(data).encode('utf-8'))
+                                unicode_to_ascii_str(self.name),
+                                unicode_to_ascii_str(self._partition_key(data)))
         try:
             message_data = msgpack.packb(data)
         except TypeError:

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -73,7 +73,7 @@ class NonblockingStream(object):
             init(*config.get_zmq_config())
 
     def _partition_key(self, data):
-        return str(data[self.partition_key])
+        return unicode(data[self.partition_key])
 
     def _serialize_context(self, data):
         # Our sending format is made up of two messages. The first has a

--- a/triton/nonblocking_stream.py
+++ b/triton/nonblocking_stream.py
@@ -10,6 +10,8 @@ It does this by sending the messageover ZeroMQ to tritond.
 Adapted from https://github.com/rhettg/BlueOx/blob/master/blueox/network.py
 
 """
+from __future__ import unicode_literals
+from builtins import str
 import logging
 import threading
 import struct
@@ -84,8 +86,8 @@ class NonblockingStream(object):
             raise ValueError("Partition Key Too Long")
 
         meta_data = struct.pack(META_STRUCT_FMT, META_STRUCT_VERSION,
-                                self.name,
-                                self._partition_key(data))
+                                self.name.encode('utf-8'),
+                                self._partition_key(data).encode('utf-8'))
         try:
             message_data = msgpack.packb(data)
         except TypeError:


### PR DESCRIPTION
This PR patches unicode incompatibilities in`nonblocking_stream.py`.

**First**, `from __future__ import unicode_literals` has been added to the top of `nonblocking_stream.py` to enforce unicode string literals in the entire file (it will be added to all non-test files in triton, soon).

**Second**, the string arguments to `struct.pack` have been converted back from unicode to ascii (escaping out any >1byte unicode characters) by calling `.encode('utf-8')`.

**Third**, Calls `msgpack` have been changed to _always_ return utf-8 strings when _unpacking_ (escaped ascii strings and the equivalent unicode string both get converted to the same form by msgpack, fortunately).