### PR TITLE
Introducing Stream Interface + Pubsub Support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,4 +32,4 @@ pipeline:
       - DISABLE_GRPC=1
       - PUBSUB_EMULATOR_HOST=gcloud:8085
     commands:
-      - testify tests
+      - testify tests/test_composite.py

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,13 @@ workspace:
   base: /triton
   path: src
 
+services:
+  gcloud:
+    image: quay.io/postmates/gcloud-pubsub-emulator
+    environment:
+      - HOST_PORT=0.0.0.0:8085
+      - DATA_DIR=/tmp/gcloud/pubsub
+
 pipeline:
   test-docker-image:
     image: docker
@@ -14,7 +21,15 @@ pipeline:
     commands:
       docker build -t triton:${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8} -f Dockerfile.dev .
 
+  test-gcloud:
+    image: alpine:3.5
+    commands:
+      - ping -c 3 gcloud
+
   test-unit:
     image: *test_image_versioned
+    environment:
+      - DISABLE_GRPC=1
+      - PUBSUB_EMULATOR_HOST=gcloud:8085
     commands:
       - testify tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,4 +32,4 @@ pipeline:
       - DISABLE_GRPC=1
       - PUBSUB_EMULATOR_HOST=gcloud:8085
     commands:
-      - testify tests/test_composite.py
+      - testify tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 # vim: set ts=2 sts=2 sw=2 et:
 
-test_image_versioned: &test_image_versioned triton:${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8}
+test_image_versioned: &test_image_versioned triton:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8}
 
 workspace:
   base: /triton
@@ -19,7 +19,7 @@ pipeline:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     commands:
-      docker build -t triton:${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8} -f Dockerfile.dev .
+      docker build -t triton:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8} -f Dockerfile.dev .
 
   test-gcloud:
     image: alpine:3.5

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ Note - It is assumed that the given service account private key provides the pro
 
 Given Pubsub's simplified interface, clients are not able to control which storage nodes in the data plane a given message is published to.  As is the case with Kinesis streams.
 
+#### Multiplexing
+
+Streams can also be configured to represent multiple downstream providers.  For example, the stream alias `my_composite_stream` can be configured to publish events to both Kinesis and Pubsub as follows:
+
+```yaml
+my_composite_stream:
+  -
+    provider: aws
+    name: my_kinesis_stream
+    partition_key: value
+    region: us-west-1
+
+  -
+    provider: gcp
+    project: my_project
+    topic: my_topic
+    private_key_file: /path/to/service/account/private.key
+```
+
 ### Demo
 
 Triton comes with a command line script `triton` which can be used to demo some simple functionality.
@@ -69,7 +88,6 @@ Adding records to the stream is easy:
 
     s = triton.get_stream('my_stream', c)
     s.put(value='hi mom', ts=time.time())
-
 
 For more advanced uses, you can record the shard and sequence number returned
 by the put operation.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The DB also needs to have a specific table created; calling the following will i
 
 Triton checkpointing also requires a unique client name, since the basic
 assumption is that the checkpoint DB will be shared. The client name is specified
-by the ENV variable `TRITON_CLIENT_NAME`. 
+by the ENV variable `TRITON_CLIENT_NAME`.
 Attempting to checkpoint without this ENV variable will also raise a
 `TritonCheckpointError` exception.
 
@@ -247,7 +247,47 @@ Or using the API, something like:
 
 #### Pubsub
 
- TODO
+The following example sets up a Pubsub consumer which pulls messages from the horizon of the configured topic until Google closes connection due to inactivity:
+
+```python
+import triton
+
+config = triton.load_config("/etc/triton.yaml")
+stream = triton.get_stream("my_gcp_stream", config)
+
+for message in s:
+   print message
+```
+
+Note - Messages are acknowledged as new messages are returned from the iterator.  Furthermore, a subscription named as `triton-uuid.uuid4.hex` is created on behalf of the user.
+
+The above example can also be expressed as follows in order to handle cases where publishers may not publish events for a sufficiently long period of time:
+
+```
+import triton
+
+config = triton.load_config("/etc/triton.yaml")
+stream = triton.get_stream("my_gcp_stream", config)
+iterator = triton.get_iterator_from_latest()
+
+for message in iterator:
+   print message
+```
+
+Pubsub consumers can also resume from a named subscription:
+
+```python
+import triton
+
+subscription_id = 'my-subscription'
+config = triton.load_config("/etc/triton.yaml")
+stream = triton.get_stream("my_gcp_stream", config)
+
+for message in s.build_iterator_from_checkpoint(subscription_id):
+   print message
+```
+
+Note - The user must create the subscription prior to consumption otherwise an exception will be raised.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Given Pubsub's simplified interface, clients are not able to control which stora
 
 #### Multiplexing
 
-Streams can also be configured to represent multiple downstream providers.  For example, the stream alias `my_composite_stream` can be configured to publish events to both Kinesis and Pubsub as follows:
+Streams can also be configured to represent multiple downstream providers.  For example, the stream alias `my_composite_stream` can be configured to interact with both Kinesis and Pubsub as follows:
 
 ```yaml
 my_composite_stream:
@@ -259,7 +259,7 @@ for message in s:
    print message
 ```
 
-Note - Messages are acknowledged as new messages are returned from the iterator.  Furthermore, a subscription named as `triton-uuid.uuid4.hex` is created on behalf of the user.
+Note - Messages are acknowledged as new messages are returned from the iterator.  Furthermore, a subscription prefixed with `triton-` is created on behalf of the user.
 
 The above example can also be expressed as follows in order to handle cases where publishers may not publish events for a sufficiently long period of time:
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,49 @@
 # Triton Project
 
-Python Utility code for building a Data Pipeline with AWS Kinesis.
+Python Utility For Building Data Pipelines for  AWS Kinesis & Google Pubsub.
 
-See [Triton](https://github.com/postmates/go-triton)
-
-Kinesis (http://aws.amazon.com/kinesis/) lets you define streams of records.
-You put records in one end, and the other end can consumer them. The stream
-maintains the records for 24 hours. These streams come in multiple shards
-(defined by the adminstrator).
-
-The tooling provided here builds on top of the boto library to make real-world
-work with these streams and record easier. This is preferential to using the
-Amazon provided KCL (Kinesis Client Library) which is Java-based, or the python
-bindings built on top of KCL, because it isn't very pythonic.
-
-This tooling also provides built in support for checkpointing, which allows a client to pick up processing records wherever it stopped last. The raw kinesis libraries require the client to take care of the checkpointing process itself.
+See also - [Triton](https://github.com/postmates/go-triton)
 
 ### Configuration
+
+#### Kinesis
 
 Normal AWS credential environment variables or IAM roles for boto apply.
 
 Clients will need to define a yaml file containing definitions for the streams
 they will want to use. That yaml file will look like:
 
-    my_stream:
-      name: my_stream_v2
-      partition_key: value
-      region: us-west-1
+```yaml
+my_stream:
+  name: my_stream_v2
+  partition_key: value
+  region: us-west-1
+```
 
 Clients generating records will reference the `my_stream` stream which will
 automatically know to use the real underlying stream of `my_stream_v2` in the
 `us-west-1` region. Records put into this stream are assumed to have a key
 named `value` which is use for partitioning.
 
+#### Pubsub
+
+Triton can also be configured to use [Google Pubsub](https://cloud.google.com/pubsub/docs/).
+
+The following config entry enables interaction with the Pubsub topic `my_pubsub_stream`:
+
+```yaml
+my_pubsub_stream:
+  provider: gcp
+  project: my_project
+  topic: my_topic
+  private_key_file: /path/to/service/account/private.key
+```
+
+Note - It is assumed that the given service account private key provides the proper permissions to the topic - read access for consumption
+and/or write access for publication.
+
+Given Pubsub's simplified interface, clients are not able to control which storage nodes in the data plane a given message is published to.
+As is the case with Kinesis streams.
 
 ### Demo
 
@@ -70,26 +81,21 @@ by the put operation.
 You could in theory communicate these values to some other process if you want
 to ensure they have received this record.
 
-__CAVEAT UTILITOR__: Triton currently only supports data types directly converatible
+__CAVEAT UTILITOR__: Triton currently only supports data types directly convertible
 into [msgpack formated data](https://github.com/msgpack/msgpack/blob/master/spec.md).
 Unsupported types will raise a `TypeError`.
 
 ### Non-Blocking Producers and `tritond`
 
 Using the producer syntax above, `s.put(value='hi mom', ts=time.time())`, will block until
-the operation to put the data into Kinesis is complete, which can take on the order of 100 ms.
+the operation to put the data is complete, which can take on the order of 100 ms.
 This guarantees that the write has succeeded before continuing the flow of control.
 
 To allow for writes that do not block, triton comes with `tritond`;
-a daemon that will spool Kinesis messages to local memory and write those messages to Kinesis asynchronously.
-Writes via this pathway block for approximately 0.1 ms.
-The `tritond` spools messages to memory and writes all recieved messages to Kinesis
-every 100 ms.
+a daemon that will spool events to local memory and write those messages to the configured backend asynchronously.
+Writes via this pathway block for approximately 0.1 ms.  `tritond` flushes events every 100ms.
 It is important to note that using this non-blocking pathway eliminates the guarantee
-that data will be written to Kinesis.
 
-An instance of `tritond` needs be running to collect Kinesis writes.
-It is recomended to run an instance on each host that will be producing Kinesis writes.
 By default, `tritond` will listen on `127.0.0.1:3515` or it will
 respect the environment variables `TRITON_ZMQ_HOST` and `TRITON_ZMQ_PORT`.
 The `tritond` uses the same `triton.yaml` files to configure triton streams;
@@ -112,13 +118,13 @@ Once `tritond` is running, usage follows the basic write pattern:
     s = triton.get_nonblocking_stream('my_stream', c)
     s.put(value='hi mom', ts=time.time())
 
-Since the actual Kinesis write happens asynchronously, the shard and sequence number
-are not returned from this operation. 
-Also, as mentioned above, Triton currently only supports data types directly converatible
+Also, as mentioned above, Triton currently only supports data types directly convertible
 into [msgpack formated data](https://github.com/msgpack/msgpack/blob/master/spec.md).
 For data put into a `NonblockingStream` object, unsupported types will log an error and continue.
 
 ### Consumers
+
+#### Kinesis
 
 Writing consumers is more complicated as you must deal with sharding. Even in
 the lightest of workloads you'll likely want to have multiple shards. Triton makes this simple:
@@ -166,7 +172,7 @@ and the second worker would do:
 Note that these are 'share numbers', not shard ids. These are indexes into the
 actual shard list.
 
-### Checkpointing
+##### Checkpointing
 
 Triton supports checkpointing to a DB so that processing can start where
 previous processing left off. It requires a postgresDB available.
@@ -206,7 +212,7 @@ For example:
 The next time this code is run, it will pick up from where the last run left off.
 
 
-### Consuming Archives
+##### Consuming Archives
 
 Triton data is typically archived to S3. Using the triton command, you can view that data:
 
@@ -223,6 +229,9 @@ Or using the API, something like:
     for rec in s:
         ... do something ...
 
+#### Pubsub
+
+ TODO
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ my_pubsub_stream:
   private_key_file: /path/to/service/account/private.key
 ```
 
-Note - It is assumed that the given service account private key provides the proper permissions to the topic - read access for consumption
-and/or write access for publication.
+Note - It is assumed that the given service account private key provides the proper permissions to the topic - read access for consumption and/or write access for publication.
 
-Given Pubsub's simplified interface, clients are not able to control which storage nodes in the data plane a given message is published to.
-As is the case with Kinesis streams.
+Given Pubsub's simplified interface, clients are not able to control which storage nodes in the data plane a given message is published to.  As is the case with Kinesis streams.
 
 ### Demo
 

--- a/README.md
+++ b/README.md
@@ -291,17 +291,49 @@ Note - The user must create the subscription prior to consumption otherwise an e
 
 ## Development
 
+### Drone
+
+Every pull request triggers automated unit and integration testing via drone.
+
+The following illustrates how to run the drone pipeline locally:
+
+#### Requirements
+
+* Minikube
+* Docker (installed and configured to use minikube)
+
+  ```
+  eval $(minikube docker-env)
+  ```
+
+* Drone >= 0.7.3
+
+#### Execute the Pipeline
+
+```
+make test-drone
+```
+
+### Ubuntu
+
 You should be able to configure your development environment using make:
 
     ~/python-triton $ make dev
 
 You will likely need to install system libraries as well:
 
-    ~/python-triton $ sudo apt-get install libsnappy-dev libzmq-dev
+    ~/python-triton $ export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+    ~/python-triton $ echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    ~/python-triton $ curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    ~/python-triton $ sudo apt-get update && sudo apt-get install libsnappy-dev libzmq-dev google-cloud-sdk
+
+Start Google's Pubsub emulator:
+
+    ~/python-triton $ gcloud beta emulators pubsub start --host-port=localhost:8085
 
 The tests should all work:
 
-    ~/python-triton $ make test
+    ~/python-triton $ PUBSUB_EMULATOR_HOST=localhost:8085 make test
     .
     PASSED.  1 test / 1 case: 1 passed, 0 failed.  (Total test time 0.00s)
 

--- a/cfg/requirements.txt
+++ b/cfg/requirements.txt
@@ -11,4 +11,5 @@ python-snappy
 pyzmq
 pyyaml
 psycopg2
+google-cloud-pubsub==0.27.0
 -e git://github.com/postmates/pystatsd.git@2.0.0#egg=pystatsd

--- a/ci/containers/gcloud-pubsub-emulator/Dockerfile
+++ b/ci/containers/gcloud-pubsub-emulator/Dockerfile
@@ -1,0 +1,10 @@
+# Emulator used by testing pipeline.  Available at: quay.io/postmates/gcloud-pubsub-emulator.
+
+FROM google/cloud-sdk
+
+ENV DATA_DIR "/tmp/gcloud/pubsub"
+ENV HOST_PORT 0.0.0.0:8042
+
+RUN mkdir -p ${DATA_DIR}
+
+CMD gcloud beta emulators pubsub start --host-port=$HOST_PORT --verbosity=error --data-dir=$DATA_DIR 2> /dev/null

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     author_email=get_init_val('author_email'),
     url=get_init_val('url'),
     scripts=glob.glob("bin/triton*"),
-    install_requires=['python-snappy', 'msgpack_python', 'pyzmq', 'future'],
+    install_requires=['python-snappy', 'msgpack_python', 'pyzmq', 'future', 'google-cloud-pubsub'],
     packages=PACKAGES
 )

--- a/tests/pubsub_util.py
+++ b/tests/pubsub_util.py
@@ -1,7 +1,8 @@
 import requests
 
-from testify import *
+from testify import assert_truthy, assert_equal
 from google.cloud import pubsub
+
 
 def setup(project='integration', topic_name='foobar'):
     topic_name = 'foobar'
@@ -41,8 +42,8 @@ def random_batch(size=100):
     batch = []
     for i in range(0, size):
         record = dict(
-            blob = 'foobar',
-            timestamp = i
+            blob='foobar',
+            timestamp=i
         )
 
         batch.append(record)

--- a/tests/pubsub_util.py
+++ b/tests/pubsub_util.py
@@ -1,0 +1,25 @@
+from testify import *
+from google.cloud import pubsub
+
+def fetch_all(sub):
+    results = []
+
+    while True:
+        batch = sub.pull(return_immediately=True)
+        if (batch == []) or (batch is None):
+            break
+
+        results = results + [message for ack_id, message in batch]
+        sub.acknowledge([ack_id for ack_id, message in batch])
+
+    return results
+
+def assert_stream_equals(sub, batch, decoder=None):
+    pubsub_messages = fetch_all(sub)
+    assert_truthy(len(pubsub_messages) >= len(batch))
+
+    messages = [decoder(pubsub_message) if decoder else pubsub_message for pubsub_message in pubsub_messages]
+    assert_equal(len(batch), len(messages))
+
+    for message in messages:
+        assert_truthy(message in batch)

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -176,7 +176,7 @@ class StreamIteratorCheckpointTest(TestCase):
         with mock.patch(pool_patch, new=lambda: self.pool):
             with mock.patch(chkpt_patch, new=TritonCheckpointerTest):
                 c = turtle.Turtle()
-                s = stream.Stream(c, stream_name, 'p_key')
+                s = stream.AWSStream(stream_name, 'p_key', conn=c)
                 s._shard_ids = [shard_id, ]
 
                 s.conn.get_records = get_batches_of_10_records

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,9 +1,10 @@
 import requests
+import triton
 import pubsub_util
 
 from testify import *
 from google.cloud import pubsub
-from triton import get_stream, stream
+from triton import stream
 
 class FaultyGCPException(Exception):
     pass
@@ -11,12 +12,37 @@ class FaultyGCPException(Exception):
 class FaultyGCPStream(stream.GCPStream):
 
 
-    def __init__(self):
-        pass
+    class EmptyIterator(object):
+
+
+        def __iter__(self):
+            return self
+
+
+        def __next__(self):
+            raise StopIteration
+
+
+        def next(self):
+            return self.__next__()
+
+
+    def __init__(self, raise_exception=True, **kwargs):
+        self.raise_exception = raise_exception
+        super(FaultyGCPStream, self).__init__(**kwargs)
 
 
     def put_many(self, records):
-        raise FaultyGCPException("oops")
+        if self.raise_exception:
+            raise FaultyGCPException("oops")
+
+
+    def __iter__(self):
+        return self.build_iterator_from_latest()
+
+
+    def build_iterator_from_latest(self):
+        return FaultyGCPStream.EmptyIterator()
 
 
 class CompositeTest(TestCase):
@@ -59,10 +85,9 @@ class CompositeTest(TestCase):
             pubsub_config]
 
         config = dict(my_composite_stream=composite_config)
+        composite_stream = triton.get_stream('my_composite_stream', config)
 
-        composite_stream = get_stream('my_composite_stream', config)
         assert_equal(type(composite_stream), stream.CompositeStream)
-
         assert_equal(len(composite_stream.streams), len(composite_config))
         assert_equal(type(composite_stream.streams[0]), stream.AWSStream)
         assert_equal(type(composite_stream.streams[1]), stream.GCPStream)
@@ -81,7 +106,7 @@ class CompositeTest(TestCase):
         ]
 
         config = dict(my_composite_stream=composite_config)
-        composite_stream = get_stream('my_composite_stream', config)
+        composite_stream = triton.get_stream('my_composite_stream', config)
 
         batch = [dict(blob=blob) for blob in ['foobar', 'baz', 'foomatic']]
         composite_stream.put_many(batch)
@@ -105,9 +130,129 @@ class CompositeTest(TestCase):
             topic=self.topic_name,
             private_key_file=None)
         good_pubsub = stream.GCPStream(**pubsub_config)
-        bad_pubsub = FaultyGCPStream()
+        bad_pubsub = FaultyGCPStream(**pubsub_config)
 
         composite = stream.CompositeStream([good_pubsub, bad_pubsub])
         assert_raises(FaultyGCPException, composite.put_many, batch)
 
         pubsub_util.assert_stream_equals(self.sub, batch, decoder=good_pubsub.decode)
+
+class CompositeIteratorTest(TestCase):
+
+
+
+    @setup
+    def setup(self):
+        self.project = 'integration'
+        self.topic_name = 'foobar'
+
+        self.client = pubsub.Client(project=self.project, _http=requests.Session())
+        self.topic = self.client.topic(self.topic_name)
+        self.topic.create()
+
+        self.sub = self.topic.subscription(self.project)
+        self.sub.create()
+
+
+    @teardown
+    def cleanup(self):
+        self.topic.delete()
+        self.sub.delete()
+
+
+    def get_stream(self):
+        pubsub_config = dict(
+            provider='gcp',
+            project=self.project,
+            topic=self.topic_name,
+            private_key_file=None)
+
+        composite_config = [
+            dict(**pubsub_config),
+            dict(**pubsub_config)
+        ]
+
+        config = dict(my_composite_stream=composite_config)
+        return triton.get_stream('my_composite_stream', config)
+
+
+    def test_iterator_latest(self):
+        stream = self.get_stream()
+        combo_iter = stream.build_iterator_from_latest()
+
+        batch = pubsub_util.random_batch()
+        stream.put_many(batch)
+
+        acc1 = []
+        acc2 = []
+        for record1, record2 in combo_iter:
+            acc1.append(record1)
+            acc2.append(record2)
+
+        for message in acc1:
+            assert_truthy(message in acc2)
+
+        for message in acc2:
+            assert_truthy(message in acc1)
+
+        for message in batch:
+            assert_truthy(message in acc1)
+
+
+    def test_iterator_checkpoint(self):
+        stream = self.get_stream()
+
+        subscription_id1 = 'custom-subscription-id-1'
+        subscription1 = self.topic.subscription(subscription_id1)
+        subscription1.create()
+
+        subscription_id2 = 'custom-subscription-id-2'
+        subscription2 = self.topic.subscription(subscription_id2)
+        subscription2.create()
+
+        first_batch = pubsub_util.random_batch(size=15)
+        stream.put_many(first_batch)
+        pubsub_util.fetch_all(subscription1)
+        pubsub_util.fetch_all(subscription2)
+
+        second_batch = pubsub_util.random_batch()
+        stream.put_many(second_batch)
+        combo_iter = stream.build_iterator_from_checkpoint([subscription_id1, subscription_id2])
+
+
+        acc1 = []
+        acc2 = []
+        for record1, record2 in combo_iter:
+            acc1.append(record1)
+            acc2.append(record2)
+
+        subscription1.delete()
+        subscription2.delete()
+
+        for message in acc1:
+            assert_truthy(message in acc2)
+
+        for message in acc2:
+            assert_truthy(message in acc1)
+
+        for message in second_batch:
+            assert_truthy(message in acc1)
+
+
+    def test_iterator_favors_longest(self):
+        batch = pubsub_util.random_batch(size=15)
+        pubsub_config = dict(
+            project=self.project,
+            topic=self.topic_name,
+            private_key_file=None)
+        good_pubsub = stream.GCPStream(**pubsub_config)
+        bad_pubsub = FaultyGCPStream(raise_exception=False, **pubsub_config)
+
+        composite = stream.CompositeStream([good_pubsub, bad_pubsub])
+        composite_iter = composite.build_iterator_from_latest()
+
+        composite.put_many(batch)
+
+        for good_item, bad_item in composite_iter:
+            assert_truthy(good_item in batch)
+            assert_equal(bad_item, None)

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,113 @@
+import requests
+import pubsub_util
+
+from testify import *
+from google.cloud import pubsub
+from triton import get_stream, stream
+
+class FaultyGCPException(Exception):
+    pass
+
+class FaultyGCPStream(stream.GCPStream):
+
+
+    def __init__(self):
+        pass
+
+
+    def put_many(self, records):
+        raise FaultyGCPException("oops")
+
+
+class CompositeTest(TestCase):
+
+
+    @setup
+    def setup(self):
+        self.project = 'integration'
+        self.topic_name = 'foobar'
+
+        self.client = pubsub.Client(project=self.project, _http=requests.Session())
+        self.topic = self.client.topic(self.topic_name)
+        self.topic.create()
+
+        self.sub = self.topic.subscription(self.project)
+        self.sub.create()
+
+
+    @teardown
+    def cleanup(self):
+        self.topic.delete()
+        self.sub.delete()
+
+
+    def test_construction(self):
+        kinesis_config = dict(
+            name='my_kinesis_stream',
+            partition_key='value',
+            region='us-west-1',
+            conn = requests.Session())
+
+        pubsub_config = dict(
+            provider='gcp',
+            project='foobar',
+            topic='baz',
+            private_key_file=None)
+
+        composite_config = [
+            kinesis_config,
+            pubsub_config]
+
+        config = dict(my_composite_stream=composite_config)
+
+        composite_stream = get_stream('my_composite_stream', config)
+        assert_equal(type(composite_stream), stream.CompositeStream)
+
+        assert_equal(len(composite_stream.streams), len(composite_config))
+        assert_equal(type(composite_stream.streams[0]), stream.AWSStream)
+        assert_equal(type(composite_stream.streams[1]), stream.GCPStream)
+
+
+    def test_multiplexing(self):
+        pubsub_config = dict(
+            provider='gcp',
+            project=self.project,
+            topic=self.topic_name,
+            private_key_file=None)
+
+        composite_config = [
+            dict(**pubsub_config),
+            dict(**pubsub_config)
+        ]
+
+        config = dict(my_composite_stream=composite_config)
+        composite_stream = get_stream('my_composite_stream', config)
+
+        batch = [dict(blob=blob) for blob in ['foobar', 'baz', 'foomatic']]
+        composite_stream.put_many(batch)
+
+        #Expect to receive 2x back again
+        pubsub_util.assert_stream_equals(self.sub, batch + batch, decoder=composite_stream.streams[0].decode)
+
+
+    def test_exception_results_in_loss_of_parity(self):
+        """
+            Existing retry logic is lossy, composite streams
+            carry this forward (for now) allowing events to be published
+            in one stream and go missing in the other.
+
+            In the future, when at least once delivery is achieved then this
+            test will need to be reworked.
+        """
+        batch = [dict(blob=blob) for blob in ['foobar', 'baz', 'foomatic']]
+        pubsub_config = dict(
+            project=self.project,
+            topic=self.topic_name,
+            private_key_file=None)
+        good_pubsub = stream.GCPStream(**pubsub_config)
+        bad_pubsub = FaultyGCPStream()
+
+        composite = stream.CompositeStream([good_pubsub, bad_pubsub])
+        assert_raises(FaultyGCPException, composite.put_many, batch)
+
+        pubsub_util.assert_stream_equals(self.sub, batch, decoder=good_pubsub.decode)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,20 +1,18 @@
 import os
 
-import requests
 import triton
 import pubsub_util
 import google.cloud.exceptions
 
 from testify import *
-from google.cloud import pubsub
 from triton import stream
 
 BATCH_MAX_MSGS = stream.GCPStream.BATCH_MAX_MSGS
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-class GCPTest(TestCase):
 
+class GCPTest(TestCase):
 
     @setup
     def setup(self):
@@ -22,14 +20,12 @@ class GCPTest(TestCase):
         self.topic_name = 'foobar'
         self.client, self.topic, self.sub = pubsub_util.setup(self.project, self.topic_name)
 
-
     @teardown
     def cleanup(self):
         pubsub_util.teardown(
             self.client,
             self.topic,
             self.sub)
-
 
     def get_stream(self):
         pubsub_config = dict(
@@ -39,26 +35,23 @@ class GCPTest(TestCase):
             private_key_file=None)
 
         config = dict(
-            test_stream = pubsub_config)
+            test_stream=pubsub_config)
 
         return triton.get_stream('test_stream', config)
 
-
     def test_construction(self):
-        stream = self.get_stream()
+        self.get_stream()
         assert_truthy(True) # Just ensure we survive
-
 
     def test_publish_oneoff(self):
         stream = self.get_stream()
         record = dict(
-            blob = 'foobar',
-            timestamp = 10234
+            blob='foobar',
+            timestamp=10234
         )
         stream.put(**record)
 
         pubsub_util.assert_stream_equals(self.sub, [record], decoder=stream.decode)
-
 
     def test_publish_batch(self):
         stream = self.get_stream()
@@ -66,14 +59,13 @@ class GCPTest(TestCase):
         batch = []
         for i in range(0, 101):
             record = dict(
-                blob = 'foobar',
-                timestamp = i
+                blob='foobar',
+                timestamp=i
             )
             batch.append(record)
 
         stream.put_many(batch)
         pubsub_util.assert_stream_equals(self.sub, batch, decoder=stream.decode)
-
 
     def test_publish_batch_larger_than_limits(self):
         stream = self.get_stream()
@@ -82,7 +74,6 @@ class GCPTest(TestCase):
         stream.put_many(batch)
 
         pubsub_util.assert_stream_equals(self.sub, batch, decoder=stream.decode)
-
 
     def test_publish_batch_has_too_many_bytes(self):
         stream = self.get_stream()
@@ -95,13 +86,11 @@ class GCPTest(TestCase):
 
 class GCPStreamIteratorTest(TestCase):
 
-
     @setup
     def setup(self):
         self.project = 'integration'
         self.topic_name = 'foobar'
         self.client, self.topic, self.sub = pubsub_util.setup(self.project, self.topic_name)
-
 
     @teardown
     def cleanup(self):
@@ -109,7 +98,6 @@ class GCPStreamIteratorTest(TestCase):
             self.client,
             self.topic,
             self.sub)
-
 
     def get_stream(self):
         pubsub_config = dict(
@@ -119,10 +107,9 @@ class GCPStreamIteratorTest(TestCase):
             private_key_file=None)
 
         config = dict(
-            test_stream = pubsub_config)
+            test_stream=pubsub_config)
 
         return triton.get_stream('test_stream', config)
-
 
     def test_latest_iterator_is_default(self):
         stream = self.get_stream()
@@ -135,7 +122,6 @@ class GCPStreamIteratorTest(TestCase):
         # should go unnoticed.
         for msg in stream:
             assert_truthy(False)
-
 
     def test_latest_iterator(self):
         stream = self.get_stream()
@@ -185,7 +171,6 @@ class GCPStreamIteratorTest(TestCase):
                 break
 
         sub.delete()
-
 
     def test_checkpoint_iterator_raises_when_sub_dne(self):
         stream = self.get_stream()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,0 +1,123 @@
+import os
+
+import requests
+
+from testify import *
+from google.cloud import pubsub
+from triton import stream
+
+BATCH_MAX_MSGS = stream.GCPStream.BATCH_MAX_MSGS
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+class GCPTest(TestCase):
+
+
+    @setup
+    def setup(self):
+        self.project = 'integration'
+        self.topic_name = 'foobar'
+
+        self.client = pubsub.Client(project=self.project, _http=requests.Session())
+        self.topic = self.client.topic(self.topic_name)
+        self.topic.create()
+
+        self.sub = self.topic.subscription(self.project)
+        self.sub.create()
+
+
+    @teardown
+    def cleanup(self):
+        self.topic.delete()
+        self.sub.delete()
+
+
+    def get_stream(self):
+        return stream.GCPStream(
+            project = self.project,
+            topic = self.topic_name,
+            private_key_file = None
+        )
+
+
+    def fetch_all(self):
+        results = []
+
+        while True:
+            batch = self.sub.pull(return_immediately=True)
+            if (batch == []) or (batch is None):
+                break
+
+            results = results + [message for ack_id, message in batch]
+            self.sub.acknowledge([ack_id for ack_id, message in batch])     
+
+        return results
+
+
+    def test_construction(self):
+        stream = self.get_stream()
+        assert_truthy(True) # Just ensure we survive
+
+
+    def test_publish_oneoff(self):
+        stream = self.get_stream()
+        record = dict(
+            blob = 'foobar',
+            timestamp = 10234
+        )
+        stream.put(**record)
+
+        messages = self.fetch_all()
+        assert_equal(len(messages), 1)
+        for message in messages:
+            unpacked = stream.decode(message)
+            assert_equal(record, unpacked)
+
+
+    def test_publish_batch(self):
+        stream = self.get_stream()
+
+        batch = []
+        for i in range(0, 101):
+            record = dict(
+                blob = 'foobar',
+                timestamp = i
+            )
+            batch.append(record)
+
+        stream.put_many(batch)
+
+        pubsub_messages = self.fetch_all()
+        assert_truthy(len(pubsub_messages) >= len(batch))
+
+        # Pubsub is at least once publishing, so we do some work to dedup a list of dicts.
+        message_dicts = [stream.decode(pubsub_message) for pubsub_message in pubsub_messages]
+        messages = [dict(tup) for tup in set([tuple(message_dict.items()) for message_dict in message_dicts])]
+        assert_equal(len(batch), len(messages))
+
+        for message in messages:
+            assert_truthy(message in batch)
+
+    def test_publish_batch_larger_than_limits(self):
+        stream = self.get_stream()
+
+        batch = []
+        for i in range(0, 2 * BATCH_MAX_MSGS + 10):
+            record = dict(
+                blob = 'foobar',
+                timestamp = i
+            )
+            batch.append(record)
+
+        stream.put_many(batch)
+
+        pubsub_messages = self.fetch_all()
+        assert_truthy(len(pubsub_messages) >= len(batch))
+
+        # Pubsub is at least once publishing, so we do some work to dedup a list of dicts.
+        message_dicts = [stream.decode(pubsub_message) for pubsub_message in pubsub_messages]
+        messages = [dict(tup) for tup in set([tuple(message_dict.items()) for message_dict in message_dicts])]
+        assert_equal(len(batch), len(messages))
+
+        for message in messages:
+            assert_truthy(message in batch)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -207,7 +207,7 @@ class StreamTest(TestCase):
 
     def test_partition_key(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         assert_equal(s._partition_key({'value': 1}), "1")
 
@@ -225,13 +225,13 @@ class StreamTest(TestCase):
             }
 
         c.describe_stream = describe_stream
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         assert_equal(set(s.shard_ids), set(['0001', '0002']))
 
     def test_select_shard_ids(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         s._shard_ids = ['0001', '0002', '0003']
 
         shard_ids = s._select_shard_ids([0, 2])
@@ -239,7 +239,7 @@ class StreamTest(TestCase):
 
     def test_select_shard_ids_empty(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         s._shard_ids = ['0001', '0002', '0003']
 
         shard_ids = s._select_shard_ids([])
@@ -247,7 +247,7 @@ class StreamTest(TestCase):
 
     def test_select_shard_ids_missing(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         s._shard_ids = ['0001', '0002', '0003']
 
         with assert_raises(errors.ShardNotFoundError):
@@ -261,7 +261,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         with mock.patch('pystatsd.increment') as increment:
             shard_id, seq_num = s.put(value=0)
@@ -280,7 +280,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        s = stream.Stream(c, 'test_stream', 'pkey')
+        s = stream.AWSStream('test_stream', 'pkey', conn=c)
 
         test_data = generate_messy_test_data()
         s.put(**test_data)
@@ -306,7 +306,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         assert_raises(errors.KinesisError, s.put, value=0)
 
@@ -318,7 +318,7 @@ class StreamTest(TestCase):
 
         c.put_records = put_records
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         with mock.patch('pystatsd.increment') as increment:
             resp = s.put_many([dict(value=0)])
@@ -342,7 +342,7 @@ class StreamTest(TestCase):
 
         c.put_records = put_records
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         test_data = generate_messy_test_data()
 
@@ -373,7 +373,7 @@ class StreamTest(TestCase):
 
         c.put_records = put_records
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
 
         for test_count in [1, 499, 500, 501, 1201]:
             resp = s.put_many([dict(value=0)] * test_count)
@@ -382,7 +382,7 @@ class StreamTest(TestCase):
     def test_build_iterator(self):
         c = turtle.Turtle()
 
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         shard_ids = ['0001', '0002']
 
         i = s._build_iterator(stream.ITER_TYPE_LATEST, shard_ids, None)
@@ -409,7 +409,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        st = stream.Stream(c, 'test stream', 'value')
+        st = stream.AWSStream('test stream', 'value', conn=c)
 
         shard_id, seq_num = st.put(value=0)
         assert_equal(seq_num, 1)
@@ -452,14 +452,14 @@ class StreamTest(TestCase):
 
         put_records = PutRecords()
         c.put_records = put_records
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         test_count = 600
         resp = s.put_many([dict(value=0)] * test_count)
         assert_equal(len(resp), test_count)
 
         put_records = PutRecords(fail_for_n_calls=4, initial_error_rate=1.)
         c.put_records = put_records
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         test_count = 100
         assert_raises(
             errors.KinesisPutManyError, s.put_many,
@@ -467,7 +467,7 @@ class StreamTest(TestCase):
 
         put_records = PutRecords(fail_for_n_calls=4, initial_error_rate=.5)
         c.put_records = put_records
-        s = stream.Stream(c, 'test stream', 'value')
+        s = stream.AWSStream('test stream', 'value', conn=c)
         test_count = 100
         try:
             resp = s.put_many([dict(value=0)] * test_count)

--- a/triton/config.py
+++ b/triton/config.py
@@ -12,9 +12,23 @@ ZMQ_DEFAULT_PORT = 3515
 
 log = logging.getLogger(__name__)
 
-REQUIRED_CONFIG_KEYS = ['name', 'partition_key']
+REQUIRED_CONFIG_KEYS_V1 = ['name', 'partition_key']
+
+PROVIDER_GCP = 'gcp'
+PROVIDER_AWS = 'aws'
+REQUIRED_CONFIG_KEYS_V2 = ['provider']
+REQUIRED_CONFIG_VALID_PROVIDERS_V2 = [PROVIDER_AWS, PROVIDER_GCP]
+REQUIRED_CONFIG_KEYS_AWS_V2 = REQUIRED_CONFIG_KEYS_V1
+REQUIRED_CONFIG_KEYS_GCP_V2 = ['project', 'topic', 'private_key_file']
 
 _zmq_config = None
+
+
+def _validate_config(stream_name, config, required):
+    for k in required:
+        if k not in config:
+            raise errors.InvalidConfigurationError(
+                "Missing {} : {}".format(stream_name, k))
 
 
 def load_config(file_name):
@@ -24,13 +38,16 @@ def load_config(file_name):
         log.error("Failed to open %s: %r", file_name, e)
         return None
 
-    for stream_name, v in config_dict.iteritems():
-        for k in REQUIRED_CONFIG_KEYS:
-            if k not in v:
-                raise errors.InvalidConfigurationError(
-                    "Missing {} : {}".format(stream_name, k))
+    for stream_name, stream_config in config_dict.iteritems():
+        provider = stream_config.get('provider', PROVIDER_AWS)
+        if provider not in REQUIRED_CONFIG_VALID_PROVIDERS_V2:
+            raise errors.InvalidConfigurationError(
+                "Invalid provider.  Supported providers = {}".format(REQUIRED_CONFIG_VALID_PROVIDERS_V2))
 
-    return config_dict
+        required_keys = REQUIRED_CONFIG_KEYS_AWS_V2 if provider == PROVIDER_AWS else REQUIRED_CONFIG_KEYS_GCP_V2
+        _validate_config(stream_name, stream_config, required_keys)
+
+    return dict(provider = provider, **config_dict)
 
 
 def get_zmq_config():

--- a/triton/config.py
+++ b/triton/config.py
@@ -47,7 +47,7 @@ def load_config(file_name):
         required_keys = REQUIRED_CONFIG_KEYS_AWS_V2 if provider == PROVIDER_AWS else REQUIRED_CONFIG_KEYS_GCP_V2
         _validate_config(stream_name, stream_config, required_keys)
 
-    return dict(provider = provider, **config_dict)
+    return dict(provider=provider, **config_dict)
 
 
 def get_zmq_config():

--- a/triton/errors.py
+++ b/triton/errors.py
@@ -13,6 +13,11 @@ class Error(Exception):
     pass
 
 
+class InvalidConfigurationError(Exception):
+    """Signals a stream config is invalid."""
+    pass
+
+
 class TritonNotConfiguredError(Error):
     """Indicates no config file found"""
     pass

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -440,11 +440,7 @@ class GCPStream(Stream):
 class AWSStream(Stream):
 
     def __init__(self, name, partition_key, conn=None, region='us-east-1'):
-        if conn is not None:
-            self.conn = conn
-        else:
-            self.conn = connect_to_region(region)
-
+        self.conn = conn or connect_to_region(region)
         self.name = name
         self.partition_key = partition_key
         self._shard_ids = None

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -385,13 +385,13 @@ class GCPStream(Stream):
                     self.subscription.acknowledge(self.pending_acks)
                     self.pending_acks = []
 
-                pubsub_messages = self.subscription.pull(return_immediately=False)
-                if pubsub_messages == []:
-                    raise StopIteration
+            pubsub_messages = self.subscription.pull(return_immediately=False)
+            for ack_id, raw_message in pubsub_messages:
+                self.prefetch_ack_ids.append(ack_id)
+                self.prefetch.append(self.stream.decode(raw_message))
 
-                for ack_id, raw_message in pubsub_messages:
-                    self.prefetch_ack_ids.append(ack_id)
-                    self.prefetch.append(self.stream.decode(raw_message))
+            if len(self.prefetch) == 0:
+                raise StopIteration
 
             return self.prefetch.pop(0)
 

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -425,7 +425,7 @@ class GCPStream(Stream):
             )
 
         # topic.batch defines an iterator over message_ids.
-        return [(None, message_id) for message_id in list(topic_batch)]
+        return [(None, message_id) for message_id in topic_batch]
 
     def decode(self, pubsub_message):
         return super(GCPStream, self).decode(pubsub_message.data)


### PR DESCRIPTION
Support for Pubsub and multiplexing streams across cloud providers.  The old
Stream class has become an abstract class inherited by AWSStream
(previous Stream), GCPStream, and CompositeStream.

Stream types are inferred by the structure of the config entry.  New
configuration syntax is additive and remains backwards compatible.
stream.get_stream serves as a factory method producing the appropriate
stream based on the config dictionary passed to it.