### PR TITLE
Unicode support for stream, checkpoint, and store!

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+triton (0.0.15)
+
+  * Triton supports unicode!
+
 triton (0.0.14)
 
   * Additional statsd monitoring in stream class

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This guarantees that the write has succeeded before continuing the flow of contr
 To allow for writes that do not block, triton comes with `tritond`;
 a daemon that will spool Kinesis messages to local memory and write those messages to Kinesis asynchronously.
 Writes via this pathway block for approximately 0.1 ms.
-The `tritond` spools messages to memory and writes all recieved messages to Kinesis
+The `tritond` spools messages to memory and writes all received messages to Kinesis
 every 100 ms.
 It is important to note that using this non-blocking pathway eliminates the guarantee
 that data will be written to Kinesis.
@@ -113,7 +113,7 @@ Once `tritond` is running, usage follows the basic write pattern:
     s.put(value='hi mom', ts=time.time())
 
 Since the actual Kinesis write happens asynchronously, the shard and sequence number
-are not returned from this operation. 
+are not returned from this operation.
 Also, as mentioned above, Triton currently only supports data types directly converatible
 into [msgpack formated data](https://github.com/msgpack/msgpack/blob/master/spec.md).
 For data put into a `NonblockingStream` object, unsupported types will log an error and continue.
@@ -184,7 +184,7 @@ The DB also needs to have a specific table created; calling the following will i
 
 Triton checkpointing also requires a unique client name, since the basic
 assumption is that the checkpoint DB will be shared. The client name is specified
-by the ENV variable `TRITON_CLIENT_NAME`. 
+by the ENV variable `TRITON_CLIENT_NAME`.
 Attempting to checkpoint without this ENV variable will also raise a
 `TritonCheckpointError` exception.
 

--- a/bin/triton
+++ b/bin/triton
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import unicode_literals
 import argparse
 import datetime
 import os

--- a/bin/tritond
+++ b/bin/tritond
@@ -10,6 +10,7 @@ Logging daemon for non-blocking triton events.
 Adapted from https://github.com/rhettg/BlueOx/blob/master/bin/oxd
 
 """
+from __future__ import unicode_literals
 import argparse
 import errno
 import sys

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from testify import *
 import datetime
 import time
@@ -14,11 +15,19 @@ class StreamArchiveWriterFilePathTest(TestCase):
         self.dt = datetime.datetime(2015, 7, 24)
         self.stream = store.StreamArchiveWriter({'name': "foo"}, self.dt,
                                                 "/tmp")
+        self.unicode_stream = store.StreamArchiveWriter(
+                                                {u'name': u'føø_üñîçødé_宇宙'},
+                                                self.dt, u'/tµπ_üñîçødé_宇宙')
 
     def test(self):
         assert self.stream.file_path.startswith(
             "/tmp/20150724/foo-archive-"), self.stream.file_path
         assert self.stream.file_path.endswith('.tri')
+
+    def test_unicode(self):
+        assert self.unicode_stream.file_path.startswith(
+            u'/tµπ_üñîçødé_宇宙/20150724/føø_üñîçødé_宇宙-archive-'), self.unicode_stream.file_path
+        assert self.unicode_stream.file_path.endswith(u'.tri')
 
 
 class StreamArchiveWriterWriteTest(TestCase):
@@ -28,6 +37,9 @@ class StreamArchiveWriterWriteTest(TestCase):
         self.dt = datetime.datetime(2015, 7, 24)
         self.stream = store.StreamArchiveWriter({'name': "foo"}, self.dt,
                                                 "/tmp")
+        # self.unicode_stream = store.StreamArchiveWriter(
+        #                                         {u'name': u'føø_üñîçødé_宇宙'},
+        #                                         self.dt, u'/tµπ_üñîçødé_宇宙')
 
     def test_buffer(self):
         self.stream.put(ts=time.time(), value="hello")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -98,7 +98,7 @@ class StreamArchiveWriterWriteTest(TestCase):
         assert self.unicode_stream.writer
         assert os.path.exists(unicode_to_ascii_str(self.unicode_stream.file_path))
 
-        shutil.rmtree(os.path.dirname(self.unicode_stream.file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.unicode_stream.file_path)))
 
     def test_buffer_escaped_unicode(self):
         self.escaped_unicode_stream.put(ts=time.time(), value="üñîçødé")
@@ -113,7 +113,7 @@ class StreamArchiveWriterWriteTest(TestCase):
         assert self.escaped_unicode_stream.writer
         assert os.path.exists(unicode_to_ascii_str(self.escaped_unicode_stream.file_path))
 
-        shutil.rmtree(os.path.dirname(self.escaped_unicode_stream.file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.escaped_unicode_stream.file_path)))
 
 
 class StreamArchiveReaderShortTest(TestCase):
@@ -188,7 +188,7 @@ class StreamArchiveReaderShortTest(TestCase):
     def cleanup_data(self):
         shutil.rmtree(os.path.dirname(self.file_path))
         shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.unicode_file_path)))
-        shutil.rmtree(os.path.dirname(self.escaped_unicode_file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.escaped_unicode_file_path)))
 
 
 class StreamArchiveReaderFullTest(TestCase):
@@ -282,4 +282,4 @@ class StreamArchiveReaderFullTest(TestCase):
     def cleanup_data(self):
         shutil.rmtree(os.path.dirname(self.file_path))
         shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.unicode_file_path)))
-        shutil.rmtree(os.path.dirname(self.escaped_unicode_file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.escaped_unicode_file_path)))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,9 +15,20 @@ class StreamArchiveWriterFilePathTest(TestCase):
         self.dt = datetime.datetime(2015, 7, 24)
         self.stream = store.StreamArchiveWriter({'name': "foo"}, self.dt,
                                                 "/tmp")
+
+    @setup
+    def build_unicode_stream(self):
+        self.dt_u = datetime.datetime(2015, 7, 24)
         self.unicode_stream = store.StreamArchiveWriter(
                                                 {u'name': u'føø_üñîçødé_宇宙'},
-                                                self.dt, u'/tµπ_üñîçødé_宇宙')
+                                                self.dt_u, u'/tmp/uni')
+
+    @setup
+    def build_escaped_unicode_stream(self):
+        self.dt_ue = datetime.datetime(2015, 7, 24)
+        self.escaped_unicode_stream = store.StreamArchiveWriter(
+                                                {'name': 'føø_üñîçødé_宇宙_esc'},
+                                                self.dt_ue, '/tmp/uni-esc')
 
     def test(self):
         assert self.stream.file_path.startswith(
@@ -26,8 +37,14 @@ class StreamArchiveWriterFilePathTest(TestCase):
 
     def test_unicode(self):
         assert self.unicode_stream.file_path.startswith(
-            u'/tµπ_üñîçødé_宇宙/20150724/føø_üñîçødé_宇宙-archive-'), self.unicode_stream.file_path
+            u'/tmp/uni/20150724/føø_üñîçødé_宇宙-archive-'), self.unicode_stream.file_path
         assert self.unicode_stream.file_path.endswith(u'.tri')
+
+    #NOTE: as usual, anything put in as escaped unicode will come out as unicode!
+    def test_escaped_unicode(self):
+        assert self.escaped_unicode_stream.file_path.startswith(
+            u'/tmp/uni-esc/20150724/føø_üñîçødé_宇宙_esc-archive-'), self.escaped_unicode_stream.file_path
+        assert self.escaped_unicode_stream.file_path.endswith(u'.tri')
 
 
 class StreamArchiveWriterWriteTest(TestCase):
@@ -37,9 +54,20 @@ class StreamArchiveWriterWriteTest(TestCase):
         self.dt = datetime.datetime(2015, 7, 24)
         self.stream = store.StreamArchiveWriter({'name': "foo"}, self.dt,
                                                 "/tmp")
-        # self.unicode_stream = store.StreamArchiveWriter(
-        #                                         {u'name': u'føø_üñîçødé_宇宙'},
-        #                                         self.dt, u'/tµπ_üñîçødé_宇宙')
+
+    @setup
+    def build_unicode_stream(self):
+        self.dt_u = datetime.datetime(2015, 7, 24)
+        self.unicode_stream = store.StreamArchiveWriter(
+                                                {u'name': u'føø_üñîçødé_宇宙'},
+                                                self.dt_u, u'/tmp/uni')
+
+    @setup
+    def build_escaped_unicode_stream(self):
+        self.dt_ue = datetime.datetime(2015, 7, 24)
+        self.escaped_unicode_stream = store.StreamArchiveWriter(
+                                                {'name': 'føø_üñîçødé_宇宙_escaped'},
+                                                self.dt_ue, '/tmp/uni-esc')
 
     def test_buffer(self):
         self.stream.put(ts=time.time(), value="hello")
@@ -56,6 +84,36 @@ class StreamArchiveWriterWriteTest(TestCase):
 
         shutil.rmtree(os.path.dirname(self.stream.file_path))
 
+    def test_buffer_unicode(self):
+        self.unicode_stream.put(ts=time.time(), value=u"üñîçødé")
+        assert_is(self.unicode_stream.writer, None)
+        assert self.unicode_stream.buffer.tell() > 0
+
+    def test_flush_unicode(self):
+        self.unicode_stream.put(ts=time.time(), value=u"üñîçødé")
+        self.unicode_stream.flush()
+
+        assert_equal(self.unicode_stream.buffer.tell(), 0)
+        assert self.unicode_stream.writer
+        assert os.path.exists(self.unicode_stream.file_path)
+
+        shutil.rmtree(os.path.dirname(self.unicode_stream.file_path))
+
+    def test_buffer_escaped_unicode(self):
+        self.escaped_unicode_stream.put(ts=time.time(), value="üñîçødé")
+        assert_is(self.escaped_unicode_stream.writer, None)
+        assert self.escaped_unicode_stream.buffer.tell() > 0
+
+    def test_flush_escaped_unicode(self):
+        self.escaped_unicode_stream.put(ts=time.time(), value="üñîçødé")
+        self.escaped_unicode_stream.flush()
+
+        assert_equal(self.escaped_unicode_stream.buffer.tell(), 0)
+        assert self.escaped_unicode_stream.writer
+        assert os.path.exists(self.escaped_unicode_stream.file_path)
+
+        shutil.rmtree(os.path.dirname(self.escaped_unicode_stream.file_path))
+
 
 class StreamArchiveReaderShortTest(TestCase):
 
@@ -70,8 +128,38 @@ class StreamArchiveReaderShortTest(TestCase):
         writer.close()
 
     @setup
+    def create_unicode_data(self):
+        unicode_writer = store.StreamArchiveWriter(
+                                                {u'name': u'føø_üñîçødé_宇宙'},
+                                                datetime.datetime.utcnow(), u'/tmp/uni/')
+        self.unicode_file_path = unicode_writer.file_path
+
+        unicode_writer.put(ts=time.time(), value=u"hello_üñîçødé_宇宙")
+
+        unicode_writer.close()
+
+    @setup
+    def create_escaped_unicode_data(self):
+        escaped_unicode_writer = store.StreamArchiveWriter(
+                                                {'name': 'føø_üñîçødé_宇宙_escaped'},
+                                                datetime.datetime.utcnow(), '/tmp/uni-esc/')
+        self.escaped_unicode_file_path = escaped_unicode_writer.file_path
+
+        escaped_unicode_writer.put(ts=time.time(), value="hello_üñîçødé_宇宙")
+
+        escaped_unicode_writer.close()
+
+    @setup
     def build_reader(self):
         self.reader = store.StreamArchiveReader(self.file_path)
+
+    @setup
+    def build_unicode_reader(self):
+        self.unicode_reader = store.StreamArchiveReader(self.unicode_file_path)
+
+    @setup
+    def build_escaped_unicode_reader(self):
+        self.escaped_unicode_reader = store.StreamArchiveReader(self.escaped_unicode_file_path)
 
     def test(self):
         recs = list(self.reader)
@@ -80,9 +168,26 @@ class StreamArchiveReaderShortTest(TestCase):
         assert_equal(recs[0]['value'], "hello")
         assert recs[0]['ts']
 
+    def test_unicode(self):
+        u_recs = list(self.unicode_reader)
+
+        assert_equal(len(u_recs), 1)
+        assert_equal(u_recs[0][u'value'], u"hello_üñîçødé_宇宙")
+        assert u_recs[0][u'ts']
+
+    #NOTE: as usual, anything put in as escaped unicode will come out as unicode!
+    def test_escaped_unicode(self):
+        ue_recs = list(self.escaped_unicode_reader)
+
+        assert_equal(len(ue_recs), 1)
+        assert_equal(ue_recs[0]['value'], u"hello_üñîçødé_宇宙")
+        assert ue_recs[0]['ts']
+
     @teardown
     def cleanup_data(self):
         shutil.rmtree(os.path.dirname(self.file_path))
+        shutil.rmtree(os.path.dirname(self.unicode_file_path))
+        shutil.rmtree(os.path.dirname(self.escaped_unicode_file_path))
 
 
 class StreamArchiveReaderFullTest(TestCase):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,6 +6,7 @@ import os.path
 import shutil
 
 from triton import store
+from triton.encoding import unicode_to_ascii_str
 
 
 class StreamArchiveWriterFilePathTest(TestCase):
@@ -280,5 +281,5 @@ class StreamArchiveReaderFullTest(TestCase):
     @teardown
     def cleanup_data(self):
         shutil.rmtree(os.path.dirname(self.file_path))
-        shutil.rmtree(os.path.dirname(self.unicode_file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.unicode_file_path)))
         shutil.rmtree(os.path.dirname(self.escaped_unicode_file_path))

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -96,7 +96,7 @@ class StreamArchiveWriterWriteTest(TestCase):
 
         assert_equal(self.unicode_stream.buffer.tell(), 0)
         assert self.unicode_stream.writer
-        assert os.path.exists(self.unicode_stream.file_path)
+        assert os.path.exists(unicode_to_ascii_str(self.unicode_stream.file_path))
 
         shutil.rmtree(os.path.dirname(self.unicode_stream.file_path))
 
@@ -111,7 +111,7 @@ class StreamArchiveWriterWriteTest(TestCase):
 
         assert_equal(self.escaped_unicode_stream.buffer.tell(), 0)
         assert self.escaped_unicode_stream.writer
-        assert os.path.exists(self.escaped_unicode_stream.file_path)
+        assert os.path.exists(unicode_to_ascii_str(self.escaped_unicode_stream.file_path))
 
         shutil.rmtree(os.path.dirname(self.escaped_unicode_stream.file_path))
 
@@ -187,7 +187,7 @@ class StreamArchiveReaderShortTest(TestCase):
     @teardown
     def cleanup_data(self):
         shutil.rmtree(os.path.dirname(self.file_path))
-        shutil.rmtree(os.path.dirname(self.unicode_file_path))
+        shutil.rmtree(os.path.dirname(unicode_to_ascii_str(self.unicode_file_path)))
         shutil.rmtree(os.path.dirname(self.escaped_unicode_file_path))
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -271,7 +271,7 @@ class StreamTest(TestCase):
 
     def test_unicode_partition_key(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, u'test_üñîçø∂é_stream', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        s = stream.AWSStream(u'test_üñîçø∂é_stream', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙', conn=c)
 
         assert_equal(s._partition_key({u'ünîcødé_πå®tîtîøñ_ke¥_宇宙': u'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
         #NOTE: even when we throw escaped unicode in, return unicode
@@ -279,7 +279,7 @@ class StreamTest(TestCase):
 
     def test_escaped_unicode_partition_key(self):
         c = turtle.Turtle()
-        s = stream.Stream(c, 'test_üñîçø∂é_stream', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        s = stream.AWSStream('test_üñîçø∂é_stream', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙', conn=c)
         #NOTE: when we create a stream with escaped unicode, convert to unicode it works with unicode data
         assert_equal(s._partition_key({u'ünîcødé_πå®tîtîøñ_ke¥_宇宙': u'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
         #NOTE: even when we throw escaped unicode in, return unicode
@@ -383,7 +383,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        s = stream.Stream(c, u'tést_üñîçødé_stream_宇宙', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        s = stream.AWSStream(u'tést_üñîçødé_stream_宇宙', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙', conn=c)
 
         test_data = generate_unicode_test_data()
         s.put(**test_data)
@@ -404,7 +404,7 @@ class StreamTest(TestCase):
 
         c.put_record = put_record
 
-        s = stream.Stream(c, 'tést_üñîçødé_stream_宇宙', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        s = stream.AWSStream('tést_üñîçødé_stream_宇宙', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙', conn=c)
 
         test_data = generate_escaped_unicode_test_data()
         s.put(**test_data)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -249,6 +249,22 @@ class StreamTest(TestCase):
 
         assert_equal(s._partition_key({'value': 1}), "1")
 
+    def test_unicode_partition_key(self):
+        c = turtle.Turtle()
+        s = stream.Stream(c, u'test_üñîçø∂é_stream', u'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+
+        assert_equal(s._partition_key({u'ünîcødé_πå®tîtîøñ_ke¥_宇宙': u'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
+        #NOTE: even when we throw escaped unicode in, return unicode
+        assert_equal(s._partition_key({'ünîcødé_πå®tîtîøñ_ke¥_宇宙': 'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
+
+    def test_escaped_unicode_partition_key(self):
+        c = turtle.Turtle()
+        s = stream.Stream(c, 'test_üñîçø∂é_stream', 'ünîcødé_πå®tîtîøñ_ke¥_宇宙')
+        #NOTE: when we create a stream with escaped unicode, convert to unicode it works with unicode data
+        assert_equal(s._partition_key({u'ünîcødé_πå®tîtîøñ_ke¥_宇宙': u'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
+        #NOTE: even when we throw escaped unicode in, return unicode
+        assert_equal(s._partition_key({'ünîcødé_πå®tîtîøñ_ke¥_宇宙': 'ünîcødé_πå®tîtîøñ_√al_宇宙'}), u'ünîcødé_πå®tîtîøñ_√al_宇宙')
+
     def test_shards_ids(self):
         c = turtle.Turtle()
 

--- a/triton/__init__.py
+++ b/triton/__init__.py
@@ -7,7 +7,7 @@ triton
 """
 
 __title__ = 'triton'
-__version__ = '0.0.14'
+__version__ = '0.0.15'
 __description__ = 'Triton - Kinesis Data Pipeline'
 __url__ = 'https://github.com/postmates/triton-python'
 __build__ = 0

--- a/triton/checkpoint.py
+++ b/triton/checkpoint.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import os
 import logging
 import psycopg2.pool

--- a/triton/config.py
+++ b/triton/config.py
@@ -16,7 +16,9 @@ REQUIRED_CONFIG_KEYS = ['name', 'partition_key']
 
 _zmq_config = None
 
-
+#NOTE: when loading config dictionary, yaml automatically converts unicode
+#in the yaml file to unicode in the dictionary. Dictionary will still contain
+#ascii keys and values for ascii bits of yaml file
 def load_config(file_name):
     try:
         config_dict = yaml.load(io.open(file_name))

--- a/triton/config.py
+++ b/triton/config.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import io
 import yaml
 import logging

--- a/triton/config.py
+++ b/triton/config.py
@@ -18,7 +18,7 @@ _zmq_config = None
 
 #NOTE: when loading config dictionary, yaml automatically converts unicode
 #in the yaml file to unicode in the dictionary. Dictionary will still contain
-#ascii keys and values for ascii bits of yaml file
+#ascii keys and values for ascii strings in the yaml file
 def load_config(file_name):
     try:
         config_dict = yaml.load(io.open(file_name))

--- a/triton/encoding.py
+++ b/triton/encoding.py
@@ -11,7 +11,7 @@ def msgpack_encode_default(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
     if isinstance(obj, datetime.datetime):
-        return obj.isoformat(' ')
+        return obj.isoformat(str(' '))
     if isinstance(obj, datetime.date):
         return obj.strftime("%Y-%m-%d")
     if hasattr(obj, 'coords'):

--- a/triton/encoding.py
+++ b/triton/encoding.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import decimal
 import datetime
 

--- a/triton/errors.py
+++ b/triton/errors.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 """
 This module contains the set of triton's exceptions
 

--- a/triton/store.py
+++ b/triton/store.py
@@ -11,6 +11,7 @@ import msgpack
 import snappy
 import boto.s3
 from boto.s3.connection import OrdinaryCallingFormat
+from encoding import ascii_to_unicode_str
 
 MAX_BUFFER_SIZE = 1024 * 1024
 
@@ -31,7 +32,7 @@ class StreamArchiveWriter(object):
     @property
     def file_path(self):
         date_str = self.base_dt.strftime('%Y%m%d')
-        file_name = "{}-archive-{}.tri".format(self.config['name'],
+        file_name = "{}-archive-{}.tri".format(ascii_to_unicode_str(self.config['name']),
                                                int(self.ts))
         return os.path.join(self.base_path, date_str, file_name)
 
@@ -75,7 +76,7 @@ def decoder(stream):
     """Generator that processes data from the stream (by iterating) and yields
     triton records"""
     snappy_stream = snappy.StreamDecompressor()
-    unpacker = msgpack.Unpacker()
+    unpacker = msgpack.Unpacker(encoding='utf-8')
     for data in stream:
         buf = snappy_stream.decompress(data)
         if buf:

--- a/triton/store.py
+++ b/triton/store.py
@@ -11,7 +11,7 @@ import msgpack
 import snappy
 import boto.s3
 from boto.s3.connection import OrdinaryCallingFormat
-from encoding import ascii_to_unicode_str, unicode_to_ascii_str
+from encoding import ascii_to_unicode_str
 
 MAX_BUFFER_SIZE = 1024 * 1024
 
@@ -54,7 +54,7 @@ class StreamArchiveWriter(object):
             except OSError:
                 pass
 
-            self.writer = io.open(unicode_to_ascii_str(self.file_path), mode=str("wb"))
+            self.writer = io.open(self.file_path, mode="wb")
             self.snappy_compressor = snappy.StreamCompressor()
 
         data = self.snappy_compressor.add_chunk(self.buffer.getvalue())
@@ -92,7 +92,7 @@ class StreamArchiveReader(object):
         self.file_path = file_path
 
     def __iter__(self):
-        f = io.open(unicode_to_ascii_str(self.file_path), mode="rb")
+        f = io.open(self.file_path, mode="rb")
         return decoder(f)
 
 

--- a/triton/store.py
+++ b/triton/store.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import time
 import io
 import datetime

--- a/triton/store.py
+++ b/triton/store.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import time
 import io
 import datetime
@@ -92,7 +91,7 @@ class StreamArchiveReader(object):
         self.file_path = file_path
 
     def __iter__(self):
-        f = io.open(self.file_path, mode="rb")
+        f = io.open(unicode_to_ascii_str(self.file_path), mode="rb")
         return decoder(f)
 
 

--- a/triton/store.py
+++ b/triton/store.py
@@ -11,7 +11,7 @@ import msgpack
 import snappy
 import boto.s3
 from boto.s3.connection import OrdinaryCallingFormat
-from encoding import ascii_to_unicode_str
+from encoding import ascii_to_unicode_str, unicode_to_ascii_str
 
 MAX_BUFFER_SIZE = 1024 * 1024
 
@@ -54,7 +54,7 @@ class StreamArchiveWriter(object):
             except OSError:
                 pass
 
-            self.writer = io.open(self.file_path, mode="wb")
+            self.writer = io.open(unicode_to_ascii_str(self.file_path), mode=str("wb"))
             self.snappy_compressor = snappy.StreamCompressor()
 
         data = self.snappy_compressor.add_chunk(self.buffer.getvalue())

--- a/triton/store.py
+++ b/triton/store.py
@@ -11,7 +11,7 @@ import msgpack
 import snappy
 import boto.s3
 from boto.s3.connection import OrdinaryCallingFormat
-from encoding import ascii_to_unicode_str
+from encoding import ascii_to_unicode_str, unicode_to_ascii_str
 
 MAX_BUFFER_SIZE = 1024 * 1024
 
@@ -54,7 +54,7 @@ class StreamArchiveWriter(object):
             except OSError:
                 pass
 
-            self.writer = io.open(self.file_path, mode="wb")
+            self.writer = io.open(unicode_to_ascii_str(self.file_path), mode="wb")
             self.snappy_compressor = snappy.StreamCompressor()
 
         data = self.snappy_compressor.add_chunk(self.buffer.getvalue())
@@ -92,7 +92,7 @@ class StreamArchiveReader(object):
         self.file_path = file_path
 
     def __iter__(self):
-        f = io.open(self.file_path, mode="rb")
+        f = io.open(unicode_to_ascii_str(self.file_path), mode="rb")
         return decoder(f)
 
 

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -41,7 +41,7 @@ class Record(object):
 
     @classmethod
     def _decode_record_data(cls, record_data):
-        return msgpack.unpackb(base64.b64decode(record_data))
+        return msgpack.unpackb(base64.b64decode(record_data), encoding='utf-8')
 
     @classmethod
     def from_raw_record(cls, shard_id, raw_record):

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import base64
 import time
 import logging

--- a/triton/stream.py
+++ b/triton/stream.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import abc
 import base64
 import time
@@ -281,7 +282,7 @@ class Stream(object):
         return data
 
     def decode(self, record_blob):
-        return msgpack.unpackb(record_blob)
+        return msgpack.unpackb(record_blob, encoding='utf-8')
 
     def __iter__(self):
         return self.build_iterator_from_latest()
@@ -441,8 +442,8 @@ class AWSStream(Stream):
 
     def __init__(self, name, partition_key, conn=None, region='us-east-1'):
         self.conn = conn or connect_to_region(region)
-        self.name = name
-        self.partition_key = partition_key
+        self.name = ascii_to_unicode_str(name)
+        self.partition_key = ascii_to_unicode_str(partition_key)
         self._shard_ids = None
 
         super(AWSStream, self).__init__()


### PR DESCRIPTION
My last PR was about unicode (UTF-8) support for non-blocking stream. This PR is unicode support for all the other parts of triton! It also patches a few issues that caused tests to fail on drone (tests would pass locally, so issue wasn't apparent until drone ran tests).