### PR TITLE
Add boto dependency for py-triton

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+triton (0.0.19)
+
+  * Add boto to setup.py's install_requires
+
 triton (0.0.18)
 
   * Remove debug logs for nonblocking stream

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     author_email=get_init_val('author_email'),
     url=get_init_val('url'),
     scripts=glob.glob("bin/triton*"),
-    install_requires=['python-snappy', 'msgpack_python', 'pyzmq', 'future'],
+    install_requires=['python-snappy', 'msgpack_python', 'pyzmq', 'future', 'boto'],
     packages=PACKAGES
 )

--- a/triton/__init__.py
+++ b/triton/__init__.py
@@ -7,7 +7,7 @@ triton
 """
 
 __title__ = 'triton'
-__version__ = '0.0.18'
+__version__ = '0.0.19'
 __description__ = 'Triton - Kinesis Data Pipeline'
 __url__ = 'https://github.com/postmates/triton-python'
 __build__ = 0


### PR DESCRIPTION
This adds `boto` library dependency for it, so `boto` will be automatically installed