### PR TITLE
Coerce the Triton client port to an integer

### DIFF
--- a/triton/config.py
+++ b/triton/config.py
@@ -40,7 +40,8 @@ def get_zmq_config():
     global _zmq_config
     if not _zmq_config:
         zmq_host = os.environ.get(ENV_VAR_TRITON_ZMQ_HOST, ZMQ_DEFAULT_HOST)
-        zmq_port = os.environ.get(ENV_VAR_TRITON_ZMQ_PORT, ZMQ_DEFAULT_PORT)
+        zmq_port = int(os.environ.get(ENV_VAR_TRITON_ZMQ_PORT,
+                                      ZMQ_DEFAULT_PORT))
         _zmq_config = (zmq_host, zmq_port)
 
     return _zmq_config


### PR DESCRIPTION
Fixes:

```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/postmates/virtualenv.d/postal-main/lib/python2.7/site-packages/triton/nonblocking_stream.py", line 128, in get_nonblocking_stream
    return NonblockingStream(stream_name, s_config['partition_key'])
  File "/postmates/virtualenv.d/postal-main/lib/python2.7/site-packages/triton/nonblocking_stream.py", line 73, in __init__
    init(*config.get_zmq_config())
  File "/postmates/virtualenv.d/postal-main/lib/python2.7/site-packages/triton/nonblocking_stream.py", line 53, in init
    _connect_str = "tcp://%s:%d" % (host, port)
TypeError: %d format: a number is required, not str
```