### PR TITLE
Interrupt publishing to deprecated streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ env
 .DS_Store
 MANIFEST
 .cache
+src/
+.python-version

--- a/bin/tritond
+++ b/bin/tritond
@@ -45,6 +45,7 @@ POLL_LOOP_TIMEOUT_MS = 100
 # Note that pystatsd writes raise no exception if no statsd server is running
 STATSD_PREFIX = 'tritond.'
 STATSD_EVENTCOUNT = STATSD_PREFIX + "eventcount."
+STATSD_SKIPCOUNT = STATSD_PREFIX + "skipcount."
 STATSD_LOOPTIME = STATSD_PREFIX + "write_loop.timing"
 
 log = logging.getLogger("triton.d")
@@ -54,6 +55,11 @@ _streams = dict()
 
 # version byte in our meta struct for JSON meta.
 META_STRUCT_VERSION_JSON = 0x7B
+
+# We are in the process of deprecating triton/kinesis and would like to
+# interrupt the publishing of all events not sent to a stream that is
+# still being read by a consumer.
+STREAM_WHITELIST = set(['delivery_event', 'courier_event'])
 
 
 def setup_logging(options):
@@ -308,10 +314,17 @@ def main():
                 log.warning("Failed to decode event due to version mismatch")
                 continue
 
-            waiting_messages[stream_name].append({
-                'Data': event_data,
-                'PartitionKey': partition_key
-            })
+            # As stated above, triton/kinesis are being deprecated and we only
+            # want to publish to streams that are being read by a consumer.
+            if any([
+                    stream_name.startswith(stream_prefix)
+                    for stream_prefix in STREAM_WHITELIST]):
+                waiting_messages[stream_name].append({
+                    'Data': event_data,
+                    'PartitionKey': partition_key
+                })
+            else:
+                pystatsd.increment(STATSD_SKIPCOUNT + stream_name)
 
         last_write, waiting_messages = _maybe_flush_events(waiting_messages, last_write, output_file)
 

--- a/bin/tritond
+++ b/bin/tritond
@@ -57,9 +57,19 @@ _streams = dict()
 META_STRUCT_VERSION_JSON = 0x7B
 
 # We are in the process of deprecating triton/kinesis and would like to
-# interrupt the publishing of all events not sent to a stream that is
-# still being read by a consumer.
-STREAM_WHITELIST = set(['delivery_event', 'courier_event'])
+# interrupt the publishing of all events sent to a stream where there
+# are no reads from any downstream consumers.
+STREAM_BLACKLIST = set([
+    'job_event',
+    'courier_event ',
+    'courier_device_event',
+    'god_event',
+    'place_event',
+    'merchant_event',
+    'promo_event',
+    'workbench_queue_size',
+    'invoice_event',
+])
 
 
 def setup_logging(options):
@@ -318,13 +328,13 @@ def main():
             # want to publish to streams that are being read by a consumer.
             if any([
                     stream_name.startswith(stream_prefix)
-                    for stream_prefix in STREAM_WHITELIST]):
+                    for stream_prefix in STREAM_BLACKLIST]):
+                pystatsd.increment(STATSD_SKIPCOUNT + stream_name)
+            else:
                 waiting_messages[stream_name].append({
                     'Data': event_data,
                     'PartitionKey': partition_key
                 })
-            else:
-                pystatsd.increment(STATSD_SKIPCOUNT + stream_name)
 
         last_write, waiting_messages = _maybe_flush_events(waiting_messages, last_write, output_file)
 


### PR DESCRIPTION
There are a number of kinesis streams that have writes but no reads.
We don't need to publish to these streams, so we can just interrupt all
publishes to these streams.

This can be done as a lightweight way to allow for the shutdown of
the kinesis streams ($$) without having to comb through thousands of
lines of code across dozens of repositories to remove all publishes to
triton. That can be done safely at a later time.